### PR TITLE
refactor: add error to handler and typescript types

### DIFF
--- a/src/machine/index.ts
+++ b/src/machine/index.ts
@@ -183,18 +183,22 @@ export const machine = <T, D, E, Es>() => {
 
             [EventTypes.Validate]: {
               cond: 'hasSchema',
-              actions: send(
-                ({ values }, { id }) => {
-                  return { values, value: values[id], type: 'VALIDATE' };
-                },
-                { to: (_, { id }) => id as string }
-              ),
+              actions: [
+                'removeError',
+                send(
+                  ({ values }, { id }) => {
+                    return { values, value: values[id], type: 'VALIDATE' };
+                  },
+                  { to: (_, { id }) => id as string }
+                ),
+              ],
             },
 
             [EventTypes.ChangeWithValidate]: {
               cond: 'hasSchema',
               actions: [
                 'setValue',
+                'removeError',
                 send(
                   ({ values }, { value }) => ({
                     value,


### PR DESCRIPTION
Add values types based on field state and remove current error when validating field